### PR TITLE
Remove useless comparision of packet header's length with itself

### DIFF
--- a/kame/sys/netkey/key.c
+++ b/kame/sys/netkey/key.c
@@ -7427,8 +7427,7 @@ key_parse(struct mbuf *m, struct socket *so)
 	orglen = PFKEY_UNUNIT64(msg->sadb_msg_len);
 	target = KEY_SENDUP_ONE;
 
-	if ((m->m_flags & M_PKTHDR) == 0 ||
-	    m->m_pkthdr.len != m->m_pkthdr.len) {
+	if ((m->m_flags & M_PKTHDR) == 0) {
 		ipseclog((LOG_DEBUG, "key_parse: invalid message length.\n"));
 		pfkeystat.out_invlen++;
 		error = EINVAL;


### PR DESCRIPTION
This was one of the items flagged by the PVS-Studios tool:

http://www.viva64.com/en/b/0377/

Maybe, the header-length was meant to be compared with the message-length (m->m_len) -- such as to ensure, the message consists of nothing but header? Don't know -- but the current code, faithfully copied by both NetBSD and FreeBSD, makes no sense. I can not find this part in OpenBSD at all...

It would also seem, the function's second argument (socket) could use `const`-qualifier. The function-describing comment could stand English-grammar fixes too.
